### PR TITLE
Fix/remove rimraf

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@umb-network/toolbox",
-  "version": "0.6.1",
+  "version": "0.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@umb-network/toolbox",
-      "version": "0.6.1",
+      "version": "0.7.1",
       "dependencies": {
         "axios": "^0.21.1",
         "bignumber.js": "^9.0.1",
@@ -1160,6 +1160,7 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
+        "fsevents": "~2.1.2",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -1415,6 +1416,7 @@
       "dependencies": {
         "anymatch": "^1.3.0",
         "async-each": "^1.0.0",
+        "fsevents": "^1.0.0",
         "glob-parent": "^2.0.0",
         "inherits": "^2.0.1",
         "is-binary-path": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "lint": "eslint ./src/**/*.ts ./test/**/*.ts --fix",
-    "clean": "rimraf dist",
+    "clean": "rm -fr dist",
     "compile": "tsc",
     "copy:assets": "cpx 'src/**/*.{graphql,html,png,json,sol}' dist",
     "typeorm": "node --require ./node_modules/ts-node/register ./node_modules/typeorm/cli.js",


### PR DESCRIPTION
Small PR to remove the use of the npm library `rimraf` in favor of the native `rm -fr` so when cloning the project it builds straight away