### PR TITLE
Release/3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [3.3.0] - 2021-07-13
+### Added
+- add method to `ValueDecoder` that converts `bytes32` to `uint256`
+
 ## [3.2.1] - 2021-07-13
 ### Fixed
 - update `IChain` interface

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umb-network/toolbox",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {

--- a/src/contracts/lib/ValueDecoder.sol
+++ b/src/contracts/lib/ValueDecoder.sol
@@ -7,4 +7,10 @@ library ValueDecoder {
       value := mload(add(_bytes, 32))
     }
   }
+
+  function toUint(bytes32 _bytes) internal pure returns (uint256 value) {
+    assembly {
+      value := mload(add(_bytes, 32))
+    }
+  }
 }


### PR DESCRIPTION
## [3.3.0] - 2021-07-13
### Added
- add method to `ValueDecoder` that converts `bytes32` to `uint256`
