### PR TITLE
fix: Update package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [3.4.1] - 2021-08-03
+## Changed
+- update `package.json` version to 3.4.1
+
 ## [3.4.0] - 2021-08-02
 ## Added
 - add support to `KaikoPriceStream` and `KaikoSpotPrice` fetchers

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@umb-network/toolbox",
-  "version": "3.3.1",
+  "version": "3.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@umb-network/toolbox",
-      "version": "3.3.1",
+      "version": "3.4.1",
       "dependencies": {
         "axios": "~0.21.1",
         "bignumber.js": "~9.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umb-network/toolbox",
-  "version": "3.3.1",
+  "version": "3.4.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {


### PR DESCRIPTION
The last release did not update the package.json to version 3.4.0. This puts the right version. 