### PR TITLE
fix: Update RPC Selection by timestamp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@umb-network/toolbox",
-  "version": "5.5.1",
+  "version": "5.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@umb-network/toolbox",
-      "version": "5.5.1",
+      "version": "5.6.0",
       "dependencies": {
         "axios": "~0.21.1",
         "bignumber.js": "~9.0.1",
@@ -22,7 +22,7 @@
         "@types/mocha": "~8.2.0",
         "@types/moxios": "~0.4.9",
         "@types/node": "~14.14.13",
-        "@types/sinon": "^10.0.8",
+        "@types/sinon": "~10.0.8",
         "@typescript-eslint/eslint-plugin": "~4.10.0",
         "@typescript-eslint/parser": "~4.10.0",
         "chai": "~4.2.0",


### PR DESCRIPTION
This PR changes the way we're fetching the timestamp of RPCs to run in `Promise.all` instead of a `for` loop.
The previous worst-case scenario was O(timeout x amount of RPCs). The new worst-case scenario is O(amount of RPCs) 