### PR TITLE
add printableView to LeafValueCoder and test cases

### DIFF
--- a/src/services/LeafValueCoder.ts
+++ b/src/services/LeafValueCoder.ts
@@ -73,6 +73,10 @@ export class LeafValueCoder {
       return label.slice(FIXED_NUMBER_PREFIX.length);
     }
 
+    if (LeafValueCoder.isSignedValue(label)) {
+      return label.slice(SIGNED_NUMBER_PREFIX.length);
+    }
+
     return label;
   };
 

--- a/test/services/LeafValueCoder.test.ts
+++ b/test/services/LeafValueCoder.test.ts
@@ -117,6 +117,10 @@ describe('LeafValueCoder', () => {
     it('converts the key of a fixed value', () => {
       expect(LeafValueCoder.printableKey('FIXED_TEST')).to.eql('TEST');
     });
+
+    it('converts the key of a fixed value', () => {
+      expect(LeafValueCoder.printableKey('SIGN_TEST')).to.eql('TEST');
+    });
   });
 
   describe('.printableValue()', () => {
@@ -147,6 +151,36 @@ describe('LeafValueCoder', () => {
     it('converts zero value of a non-fixed value', () => {
       expect(
         LeafValueCoder.printableValue('0x0000000000000000000000000000000000000000000000000000000000000000', 'TEST')
+      ).to.eql('0');
+    });
+
+    it('converts the value of a signed value', () => {
+      expect(
+        LeafValueCoder.printableValue('0x000000000000000000000000000000000001bc16d674ec7ff21f494c589c0000', 'SIGN_TEST')
+      ).to.eql(Number.MAX_SAFE_INTEGER.toString());
+    });
+
+    it('converts value of a signed value', () => {
+      expect(
+        LeafValueCoder.printableValue('0x00000000fffffffffffffffffffffffffffe43e9298b13800de0b6b3a7640000', 'SIGN_TEST')
+      ).to.eql(Number.MIN_SAFE_INTEGER.toString());
+    });
+
+    it('converts value of a signed value', () => {
+      expect(
+        LeafValueCoder.printableValue('0x000000000000000000000000000000000000000000000000002aa1efb94e0000', 'SIGN_TEST')
+      ).to.eql('0.012');
+    });
+
+    it('converts value of a signed value', () => {
+      expect(
+        LeafValueCoder.printableValue('0x00000000ffffffffffffffffffffffffffffffffffffffff1413de11e25c0000', 'SIGN_TEST')
+      ).to.eql('-17');
+    });
+
+    it('converts zero value of a signed value', () => {
+      expect(
+        LeafValueCoder.printableValue('0x0000000000000000000000000000000000000000000000000000000000000000', 'SIGN_TEST')
       ).to.eql('0');
     });
   });


### PR DESCRIPTION
printable view support for block explorer