### PR TITLE
chore: require peer dependencies to have `ethers v5.7.2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [5.11.0] - 2023-03-07
+### Changed
+- require peer dependencies to have `ethers ^5.7.2`
+
 ## [5.10.0] - 2022-04-29
 ### Added
 - Added `TxSender`

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ const apiClient = new APIClient({
 const verificationResult = await apiClient.verifyProofForNewestBlock('ETH-USD');
 
 // output: {success: true, value: 1234, dataTimestamp: 1234567} or throw
-console.log(verificationResult) 
+console.log(verificationResult)
 ```
 
 # ContractRegistry
@@ -457,7 +457,7 @@ Response example:
 ### Signature
 
 ```shell
-async verifyProofForNewestBlock < T extends string | number = string | number > 
+async verifyProofForNewestBlock < T extends string | number = string | number >
   (key: string): Promise <{ success: boolean, value: T, dataTimestamp: Date }>
 ```
 
@@ -515,4 +515,11 @@ const latestBlockNumberRPC = await rpcSelector.selectByLatestBlockNumber();
 
 // use it to create a new ethers provider
 const provider = new JsonRpcProvider(youngestBlockAgeRPC);
+```
+
+## NPM Package
+
+```
+npm login
+npm publish
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@umb-network/toolbox",
-  "version": "5.10.0",
+  "version": "5.11.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
@@ -66,6 +66,6 @@
     "jsonschema": "~1.4.0"
   },
   "peerDependencies": {
-    "ethers": "~5.5.1"
+    "ethers": "^5.7.2"
   }
 }


### PR DESCRIPTION
After that update arbitrum goerli is better supported.